### PR TITLE
fix: allow requiring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: npm
-  directories:
-    - "/"
+  directory: "/"
   schedule:
     interval: daily
     time: "10:00"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: Close and mark stale issue
+name: Close Stale Issues
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Loading this module through a script tag will make its exports available as `Mai
 <script src="https://unpkg.com/main-event/dist/index.min.js"></script>
 ```
 
+# API Docs
+
+- <https://achingbrain.github.io/main-event>
+
 # License
 
 Licensed under either of

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "module-sync": "./src/index.js"
     }
   },
   "release": {
@@ -140,7 +141,7 @@
     "docs": "aegir docs"
   },
   "devDependencies": {
-    "aegir": "^47.0.16"
+    "aegir": "^47.1.2"
   },
   "browser": {
     "./dist/src/events.js": "./dist/src/events.browser.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@
  * ```
  */
 
-import { setMaxListeners } from './events.js'
+import { setMaxListeners } from './events.ts'
 
 export interface EventCallback<EventType> { (evt: EventType): void }
 export interface EventObject<EventType> { handleEvent: EventCallback<EventType> }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
-import { TypedEventEmitter } from '../src/index.js'
+import { TypedEventEmitter } from '../src/index.ts'
 
 describe('main-event', () => {
   it('should be an EventTarget', async () => {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,4 +1,5 @@
 {
+  "readme": "none",
   "entryPoints": [
     "./src/index.ts"
   ]


### PR DESCRIPTION
Adds `module-sync` to exports map to allow `require`ing from recent versions of Node.js