### PR TITLE
fix: ensure listener count is accurate after propagation stops

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,14 @@ export interface TypedEventTarget <EventMap extends Record<string, any>> extends
   safeDispatchEvent<Detail>(type: keyof EventMap, detail?: CustomEventInit<Detail>): boolean
 }
 
+function isEventObject <EventType> (obj?: any): obj is EventObject<EventType> {
+  return typeof obj?.handleEvent === 'function'
+}
+
+function isOnce (options?: boolean | AddEventListenerOptions): boolean {
+  return (options !== true && options !== false && options?.once) ?? false
+}
+
 /**
  * An implementation of a typed event target
  */
@@ -114,7 +122,24 @@ export class TypedEventEmitter<EventMap extends Record<string, any>> extends Eve
 
   addEventListener<K extends keyof EventMap>(type: K, listener: EventHandler<EventMap[K]> | null, options?: boolean | AddEventListenerOptions): void
   addEventListener (type: string, listener: EventHandler<Event>, options?: boolean | AddEventListenerOptions): void {
-    super.addEventListener(type, listener, options)
+    const once = isOnce(options)
+
+    super.addEventListener(type, (evt) => {
+      if (once) {
+        let list = this.#listeners.get(evt.type)
+
+        if (list != null) {
+          list = list.filter(({ callback }) => callback !== listener)
+          this.#listeners.set(evt.type, list)
+        }
+      }
+
+      if (isEventObject<Event>(listener)) {
+        listener.handleEvent(evt)
+      } else {
+        listener(evt)
+      }
+    }, options)
 
     let list = this.#listeners.get(type)
 
@@ -125,7 +150,7 @@ export class TypedEventEmitter<EventMap extends Record<string, any>> extends Eve
 
     list.push({
       callback: listener,
-      once: (options !== true && options !== false && options?.once) ?? false
+      once
     })
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,21 +168,6 @@ export class TypedEventEmitter<EventMap extends Record<string, any>> extends Eve
     this.#listeners.set(type, list)
   }
 
-  dispatchEvent (event: Event): boolean {
-    const result = super.dispatchEvent(event)
-
-    let list = this.#listeners.get(event.type)
-
-    if (list == null) {
-      return result
-    }
-
-    list = list.filter(({ once }) => !once)
-    this.#listeners.set(event.type, list)
-
-    return result
-  }
-
   safeDispatchEvent<Detail>(type: keyof EventMap, detail: CustomEventInit<Detail> = {}): boolean {
     return this.dispatchEvent(new CustomEvent<Detail>(type as string, detail))
   }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -32,7 +32,7 @@ describe('main-event', () => {
   })
 
   it('should report event listener count', () => {
-     const target = new TypedEventEmitter<EventTypes>()
+    const target = new TypedEventEmitter<EventTypes>()
 
     expect(target.listenerCount('test')).to.equal(0)
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -112,4 +112,43 @@ describe('main-event', () => {
 
     expect(target.listenerCount('test')).to.equal(0)
   })
+
+  it('should not remove `once` listener if earlier event propagation was stopped', () => {
+    interface EventTypes {
+      test: CustomEvent<string>
+    }
+    const target = new TypedEventEmitter<EventTypes>()
+    let firstListenerInvoked = false
+    let secondListenerInvoked = false
+
+    expect(target.listenerCount('test')).to.equal(0)
+
+    target.addEventListener('test', (evt) => {
+      firstListenerInvoked = true
+      evt.stopImmediatePropagation()
+    }, {
+      once: true
+    })
+
+    target.addEventListener('test', () => {
+      secondListenerInvoked = true
+    }, {
+      once: true
+    })
+
+    target.dispatchEvent(new CustomEvent('test', {
+      detail: 'hello'
+    }))
+
+    expect(firstListenerInvoked).to.be.true()
+    expect(secondListenerInvoked).to.be.false()
+    expect(target.listenerCount('test')).to.equal(1)
+
+    target.dispatchEvent(new CustomEvent('test', {
+      detail: 'world'
+    }))
+
+    expect(secondListenerInvoked).to.be.true()
+    expect(target.listenerCount('test')).to.equal(0)
+  })
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -3,6 +3,10 @@
 import { expect } from 'aegir/chai'
 import { TypedEventEmitter } from '../src/index.ts'
 
+interface EventTypes {
+  test: CustomEvent<string>
+}
+
 describe('main-event', () => {
   it('should be an EventTarget', async () => {
     const target = new TypedEventEmitter()
@@ -11,10 +15,6 @@ describe('main-event', () => {
   })
 
   it('should type event emitters', async () => {
-    interface EventTypes {
-      test: CustomEvent<string>
-    }
-
     const target = new TypedEventEmitter<EventTypes>()
     const deferred = Promise.withResolvers()
     target.addEventListener('test', (evt) => {
@@ -32,11 +32,7 @@ describe('main-event', () => {
   })
 
   it('should report event listener count', () => {
-    interface EventTypes {
-      test: CustomEvent<string>
-    }
-
-    const target = new TypedEventEmitter<EventTypes>()
+     const target = new TypedEventEmitter<EventTypes>()
 
     expect(target.listenerCount('test')).to.equal(0)
 
@@ -46,10 +42,6 @@ describe('main-event', () => {
   })
 
   it('should reduce event listener count after dispatch', () => {
-    interface EventTypes {
-      test: CustomEvent<string>
-    }
-
     const target = new TypedEventEmitter<EventTypes>()
 
     expect(target.listenerCount('test')).to.equal(0)
@@ -67,11 +59,24 @@ describe('main-event', () => {
     expect(target.listenerCount('test')).to.equal(0)
   })
 
-  it('should reduce event listener count after removal', () => {
-    interface EventTypes {
-      test: CustomEvent<string>
-    }
+  it('should reduce event listener count after dispatch when listener is an object', () => {
+    const target = new TypedEventEmitter<EventTypes>()
+    target.addEventListener('test', {
+      handleEvent: (evt) => {}
+    }, {
+      once: true
+    })
 
+    expect(target.listenerCount('test')).to.equal(1)
+
+    target.dispatchEvent(new CustomEvent('test', {
+      detail: 'hello'
+    }))
+
+    expect(target.listenerCount('test')).to.equal(0)
+  })
+
+  it('should reduce event listener count after removal', () => {
     const target = new TypedEventEmitter<EventTypes>()
 
     expect(target.listenerCount('test')).to.equal(0)
@@ -90,10 +95,6 @@ describe('main-event', () => {
   })
 
   it('should allow regular dispatch', () => {
-    interface EventTypes {
-      test: CustomEvent<string>
-    }
-
     const target = new TypedEventEmitter<EventTypes>()
 
     expect(target.listenerCount('test')).to.equal(0)
@@ -114,9 +115,6 @@ describe('main-event', () => {
   })
 
   it('should not remove `once` listener if earlier event propagation was stopped', () => {
-    interface EventTypes {
-      test: CustomEvent<string>
-    }
     const target = new TypedEventEmitter<EventTypes>()
     let firstListenerInvoked = false
     let secondListenerInvoked = false

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -5,6 +5,7 @@ import { TypedEventEmitter } from '../src/index.ts'
 
 interface EventTypes {
   test: CustomEvent<string>
+  other: CustomEvent<string>
 }
 
 describe('main-event', () => {
@@ -148,5 +149,12 @@ describe('main-event', () => {
 
     expect(secondListenerInvoked).to.be.true()
     expect(target.listenerCount('test')).to.equal(0)
+  })
+
+  it('should remove listeners that are not present', () => {
+    const target = new TypedEventEmitter<EventTypes>()
+    expect(target.listenerCount('other')).to.equal(0)
+    target.removeEventListener('other')
+    expect(target.listenerCount('other')).to.equal(0)
   })
 })


### PR DESCRIPTION
When a listener stops event propagation, one-time listeners should not be removed from the listener count.

Fixes #1